### PR TITLE
Fixed Remove Icon displaying in bootstrap 3.

### DIFF
--- a/app/views/ui/my_queue.html.haml
+++ b/app/views/ui/my_queue.html.haml
@@ -32,7 +32,7 @@
                 = link_to "TV Shows"
               %td
                 = link_to "", method: :post do
-                  %i.icon-remove
+                  %i.glyphicon.glyphicon-remove
             %tr
               %td
                 %input.form-control(type="text" value="2")
@@ -51,5 +51,5 @@
                 = link_to "TV Shows"
               %td
                 = link_to "", method: :post do
-                  %i.icon-remove
+                  %i.glyphicon.glyphicon-remove
         = button_to "Update Instant Queue", nil, class: "btn btn-default"

--- a/app/views/ui/people.html.haml
+++ b/app/views/ui/people.html.haml
@@ -18,4 +18,4 @@
           %td.extra-padding 30
           %td.extra-padding
             = link_to "", method: :post do
-              %i.icon-remove
+              %i.glyphicon.glyphicon-remove


### PR DESCRIPTION
Changed 3 places.

Change the class name `%i.icon-remove` to `%i.glyphicon.glyphicon-remove`
